### PR TITLE
make TLS support configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ futures = "0.1.17"
 tokio-core = "0.1.10"
 tokio-io = "0.1.4"
 bytes = "0.4.5"
-tokio-tls = "0.1.3"
-hyper-tls = "0.1.2"
-native-tls = "0.1.4"
+tokio-tls = { version = "0.1.3", optional=true }
+hyper-tls = { version = "0.1.2", optional=true }
+native-tls = { version = "0.1.4", optional=true }
+
+[features]
+tls = ["tokio-tls", "hyper-tls", "native-tls"]
+default = ["tls"]


### PR DESCRIPTION
There are some situations where a dependency to OpenSSL is unwanted (cross-compiling, embedded situations etc) and where the data sent is either not sensitive, already encrypted or both. This pull request makes TLS a configurable feature to make the library a little lighter and suite such use cases better.

I specifically would like this here: https://github.com/librespot-org/librespot/pull/191