### PR TITLE
Send absolute URI for HTTP as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,7 +397,7 @@ where
                     self.connector
                         .connect(proxy_dst)
                         .map_err(io_err)
-                        .map(|(s, c)| (ProxyStream::Regular(s), c)),
+                        .map(|(s, c)| (ProxyStream::Regular(s), Connected::new().proxy(true))),
                 )
             }
         } else {


### PR DESCRIPTION
When retrieving `http://` through a proxy the spec requires that
the absolute-URI be used:
https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-4.1.2

Currently path-absolute is sent.