### PR TITLE
Fix plain http connection not proxied

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ where
                             #[cfg(not(any(feature = "tls", feature = "rustls")))]
                             Some(_) => panic!("hyper-proxy was not built with TLS support"),
 
-                            None => Ok(ProxyStream::Regular(tunnel_stream)),
+                            None => Ok(ProxyStream::NoProxy(tunnel_stream)),
                         };
                     }
                 })
@@ -448,7 +448,7 @@ where
             Box::pin(
                 self.connector
                     .call(uri)
-                    .map_ok(ProxyStream::Regular)
+                    .map_ok(ProxyStream::NoProxy)
                     .map_err(|err| io_err(err.into())),
             )
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ where
                             #[cfg(not(any(feature = "tls", feature = "rustls")))]
                             Some(_) => panic!("hyper-proxy was not built with TLS support"),
 
-                            None => Ok(ProxyStream::NoProxy(tunnel_stream)),
+                            None => Ok(ProxyStream::Regular(tunnel_stream)),
                         };
                     }
                 })

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -100,7 +100,7 @@ impl<R: AsyncRead + AsyncWrite + Unpin> AsyncWrite for ProxyStream<R> {
 impl<R: AsyncRead + AsyncWrite + Connection + Unpin> Connection for ProxyStream<R> {
     fn connected(&self) -> Connected {
         match self {
-            ProxyStream::Regular(s) => s.connected(),
+            ProxyStream::Regular(s) => s.connected().proxy(true),
             #[cfg(feature = "tls")]
             ProxyStream::Secured(s) => s.get_ref().connected().proxy(true),
 


### PR DESCRIPTION
Set `Connection` for `ProxyStream::Regular` to proxied, otherwise hyper will not append host before http path