### PR TITLE
feat: add rustls-webpki feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
   - if [[ $(rustup show active-toolchain) == stable* ]]; then cargo fmt -- --check; fi;
   - cargo test --features tls
   - cargo test --features rustls --no-default-features
+  - cargo test --features rustls-webpki --no-default-features
   - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ tokio = { version = "0.2.4", features = ["full"] }
 
 [features]
 tls = ["tokio-tls", "hyper-tls", "native-tls"]
+# note that `rustls-base` is not a valid feature on its own - it will configure rustls without root
+# certificates!
 rustls-base = ["tokio-rustls", "hyper-rustls", "webpki"]
 rustls = ["rustls-base", "rustls-native-certs"]
 rustls-webpki = ["rustls-base", "webpki-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ hyper-rustls = { version="0.19", optional=true }
 
 webpki = { version = "0.21", optional = true }
 rustls-native-certs = { version = "0.1.0", optional = true }
+webpki-roots = { version = "0.20.0", optional = true }
 typed-headers = "0.2"
 
 [dev-dependencies]
@@ -36,5 +37,7 @@ tokio = { version = "0.2.4", features = ["full"] }
 
 [features]
 tls = ["tokio-tls", "hyper-tls", "native-tls"]
-rustls = ["tokio-rustls", "hyper-rustls", "webpki", "rustls-native-certs"]
+rustls-base = ["tokio-rustls", "hyper-rustls", "webpki"]
+rustls = ["rustls-base", "rustls-native-certs"]
+rustls-webpki = ["rustls-base", "webpki-roots"]
 default = ["tls"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
+## Features
+
+`hyper-proxy` exposes three main Cargo features, to configure which TLS implementation it uses to
+connect to a proxy. It can also be configured without TLS support, by compiling without default
+features entirely. The supported list of configurations is:
+
+1. No TLS support (`default-features = false`)
+2. TLS support via `native-tls` to link against the operating system's native TLS implementation
+   (default)
+3. TLS support via `rustls` (`default-features = false, features = ["rustls"]`)
+4. TLS support via `rustls`, using a statically-compiled set of CA certificates to bypass the
+   operating system's default store (`default-features = false, features = ["rustls-webpki"]`)
+
 ## Credits
 
 Large part of the code comes from [reqwest][2].


### PR DESCRIPTION
Closes #15 

This PR adds a new Cargo feature: `rustls-webpki`. This allows users to use both the `rustls` TLS stack, as well as the `webpki-roots` static CA certificates, to enable a truly independent implementation.

The basic idea is that now there are four primary versions of the library:

1. No TLS support (building with no features)
2. TLS via `native-tls` (default, using the `tls` feature)
3. TLS via `rustls` and native CA certificates (using the `rustls` feature)
4. TLS via `rustls` and compiled-in CA certificates from `webpki-roots` (using the `rustls-webpki` feature)

The two `rustls` features build off a new `rustls-base` feature, which sets up the common code between `rustls` and `rustls-webpki`. The two user-facing features then configure the `TlsConnector` in `ProxyConnector::new` based on their respective certificate store crates.

One question i have about the initial implementation: Since i introduced a separate cargo feature (`rustls-base`) to represent the common `rustls` code, there's a potential situation where someone deliberately sets the `rustls-base` feature without setting either `rustls` or `rustls-webpki` to add certificates to the TLS configuration. This will create a situation where it looks like you can set up a TLS connection to the proxy, but nothing will succeed because there are no certificates loaded into the trust store for the connection. Should we set up a guard in the library code to emit a `compile_error!()` macro if this happens?

Thanks for setting up this library! I'm looking forward to integrating it with my own. :grin: 