### PR TITLE
fix rustls-webpki feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hyper-tls = { optional = true, version = "0.4.3" }
 tokio-tls = { version = "0.3", optional=true }
 native-tls = { version = "0.2", optional=true }
 tokio-rustls = { version = "0.14", optional=true }
-hyper-rustls = { version="0.21", optional=true }
+hyper-rustls = { version="0.22.1", default-features = false, optional=true }
 
 webpki = { version = "0.21", optional = true }
 rustls-native-certs = { version = "0.4.0", optional = true }
@@ -40,6 +40,6 @@ tls = ["tokio-tls", "hyper-tls", "native-tls"]
 # note that `rustls-base` is not a valid feature on its own - it will configure rustls without root
 # certificates!
 rustls-base = ["tokio-rustls", "hyper-rustls", "webpki"]
-rustls = ["rustls-base", "rustls-native-certs"]
-rustls-webpki = ["rustls-base", "webpki-roots"]
+rustls = ["rustls-base", "rustls-native-certs", "hyper-rustls/native-tokio"]
+rustls-webpki = ["rustls-base", "webpki-roots", "hyper-rustls/webpki-tokio"]
 default = ["tls"]


### PR DESCRIPTION
Before, selecting `rustls-webpki` would have no effect
because `hyper-rustls` would always be installed using
the default feature (`rustls-native-certs`).

Now, the selected feature flags are properly propagated
into `hyper-rustls`. Also, `hyper-rustls` is bumped to
its newest version.