### PR TITLE
Derive Debug for ProxyStream

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -21,6 +21,7 @@ pub type TlsStream<R> = RustlsStream<R>;
 pub type TlsStream<R> = OpenSslStream<R>;
 
 /// A Proxy Stream wrapper
+#[derive(Debug)]
 pub enum ProxyStream<R> {
     NoProxy(R),
     Regular(R),


### PR DESCRIPTION
Hyper-boring's `HttpsConnector` requires the `Response` type to implement `Debug`.  Since `ProxyStream` doesn't implement `Debug` one cannot create a `HttpsConnector<ProxyStream<HttpConnector>>` with Boring SSL.  Compilation will fail with this error

```
error[E0277]: `ProxyStream<tokio::net::tcp::stream::TcpStream>` doesn't implement `std::fmt::Debug`
   --> src/lib.rs:75:17
    |
75  |     let https = HttpsConnector::with_connector(proxied, ssl)?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProxyStream<tokio::net::tcp::stream::TcpStream>` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `ProxyStream<tokio::net::tcp::stream::TcpStream>`
note: required by `HttpsConnector::<S>::with_connector`
   --> /home/ptwales/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-boring-2.1.1/src/lib.rs:176:5
    |
176 | /     pub fn with_connector(
177 | |         http: S,
178 | |         ssl: SslConnectorBuilder,
179 | |     ) -> Result<HttpsConnector<S>, ErrorStack> {
    | |______________________________________________^

```

It's debatable whether the change should go here or in [cloudflare/boring/hyper-boring](https://github.com/cloudflare/boring/tree/master/hyper-boring). Hyper-boring is forked from hyper-openssl and while hyper-openssl did originally have that `Debug` requirement, they dropped it when they upgraded to hyper v0.14. Hyper-boring is also on v0.14 but didn't remove that requirement.  

I'm requesting the change be implemented here in hyper-proxy because it's a one line change that won't break anything, whereas it could be many lines and many possible breakages downstream if it was in hyper-boring.

