### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
-tokio-rustls = { version = "0.22", optional = true }
-hyper-rustls = { version = "0.22", optional = true }
+tokio-rustls = { version = "0.23", optional = true }
+hyper-rustls = { version = "0.23", optional = true }
 
-webpki = { version = "0.21", optional = true }
-rustls-native-certs = { version = "0.5.0", optional = true }
-webpki-roots = { version = "0.21.0", optional = true }
+webpki = { version = "0.22", optional = true }
+rustls-native-certs = { version = "0.6.1", optional = true }
+webpki-roots = { version = "0.22.2", optional = true }
 headers = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
* Bump tokio-rustls to 0.23
* Bump hyper-rustls to 0.23
* Bump webpki to 0.22
* Bump rustls-native-certs to 0.6.1
* Bump webpki-roots to 0.22.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>