### PR TITLE
Update rustls dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
-tokio-rustls = { version = "0.22", optional = true }
-hyper-rustls = { version = "0.22", optional = true }
+tokio-rustls = { version = "0.23", optional = true }
+hyper-rustls = { version = "0.23", optional = true }
 
-webpki = { version = "0.21", optional = true }
-rustls-native-certs = { version = "0.5.0", optional = true }
-webpki-roots = { version = "0.21.0", optional = true }
+webpki = { version = "0.22", optional = true }
+rustls-native-certs = { version = "0.6.1", optional = true }
+webpki-roots = { version = "0.22.2", optional = true }
 headers = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Hello @tafia, thank you for creating hyper-proxy! I'm intending to use it, but my project uses the latest rustls and there are a lot of incompatible changes making it difficult to bridge the version I'm using and the version hyper-proxy is using. So this PR upgrades the dependencies, similar to #30, except that one seems to be missing necessary changes which I've included here.