### PR TITLE
Fix ALPN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-util = { version = "0.3", default-features = false }
 bytes = "1.0"
 hyper-tls = { version = "0.5.0", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-native-tls = { version = "0.2", optional = true }
+native-tls = { version = "0.2", optional = true, features = ["alpn"] }
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
 tokio-rustls = { version = "0.22", optional = true }


### PR DESCRIPTION
Currently, if the user chooses to use ALPN `connected` will end up returning the wrong protocol and Hyper will be unhappy, since the server will be thinking it’s h2 while Hyper thinks it’s HTTP/1.1.

Also @tafia, please if you read this hand over maintenance of this crate to the [Rust bus](https://github.com/rust-bus), the other PRs really should be merged.